### PR TITLE
fixed typo

### DIFF
--- a/app/todos/[todoId]/page.tsx
+++ b/app/todos/[todoId]/page.tsx
@@ -31,7 +31,7 @@ async function TodoPage({ params: { todoId } }: PageProps) {
             </p>
 
             <p>
-                Status: {todo.completed ? "Outstanding" : "Done"}
+                Status: {todo.completed ? "Done" : "Outstanding"}
             </p>
 
             <p className='border-t border-white mt-5 text-right border-dashed'>


### PR DESCRIPTION
Originally had minor typo in ternary operator, mistakenly had first argument set to negative value and seconf to positive.  Status: {todo.completed ? "Outstanding" : "Done"} should be if Status: {todo.completed ? "Done" : "Outstanding"}

